### PR TITLE
Add CLI check for missing SSH key

### DIFF
--- a/lavaclient/api/resource.py
+++ b/lavaclient/api/resource.py
@@ -46,9 +46,10 @@ def _prune_marshaled_data(marshaled, original_data):
 
 class Resource(object):
 
-    def __init__(self, client, command_line=False):
+    def __init__(self, client, cli_args=None):
         self._client = client
-        self._command_line = command_line
+        self._args = cli_args
+        self._command_line = cli_args is not None
 
     def _parse_response(self, data, response_class, wrapper=None):
         """

--- a/lavaclient/cli.py
+++ b/lavaclient/cli.py
@@ -75,7 +75,7 @@ def create_client(args):
                                   os.environ.get('LAVA2_API_URL'),
                                   os.environ.get('LAVA_API_URL')),
             verify_ssl=args.verify_ssl,
-            _enable_cli=args.enable_cli)
+            _cli_args=args)
     except LavaError as exc:
         six.print_('Error during authentication: {0}'.format(exc),
                    file=sys.stderr)

--- a/lavaclient/client.py
+++ b/lavaclient/client.py
@@ -66,7 +66,7 @@ auth_url=None, tenant_id=None, endpoint=None, verify_ssl=None)
                  tenant_id=None,
                  endpoint=None,
                  verify_ssl=None,
-                 _enable_cli=False):
+                 _cli_args=None):
         if not any((api_key, password, token)):
             raise error.InvalidError("One of api_key, token, or password is "
                                      "required")
@@ -112,16 +112,15 @@ auth_url=None, tenant_id=None, endpoint=None, verify_ssl=None)
             self._endpoint = self._validate_endpoint(endpoint, tenant_id)
 
         # Initialize API resources
-        self.clusters = clusters.Resource(self, command_line=_enable_cli)
-        self.limits = limits.Resource(self, command_line=_enable_cli)
-        self.flavors = flavors.Resource(self, command_line=_enable_cli)
-        self.stacks = stacks.Resource(self, command_line=_enable_cli)
-        self.distros = distros.Resource(self, command_line=_enable_cli)
-        self.workloads = workloads.Resource(self, command_line=_enable_cli)
-        self.scripts = scripts.Resource(self, command_line=_enable_cli)
-        self.nodes = nodes.Resource(self, command_line=_enable_cli)
-        self.credentials = credentials.Resource(self,
-                                                command_line=_enable_cli)
+        self.clusters = clusters.Resource(self, cli_args=_cli_args)
+        self.limits = limits.Resource(self, cli_args=_cli_args)
+        self.flavors = flavors.Resource(self, cli_args=_cli_args)
+        self.stacks = stacks.Resource(self, cli_args=_cli_args)
+        self.distros = distros.Resource(self, cli_args=_cli_args)
+        self.workloads = workloads.Resource(self, cli_args=_cli_args)
+        self.scripts = scripts.Resource(self, cli_args=_cli_args)
+        self.nodes = nodes.Resource(self, cli_args=_cli_args)
+        self.credentials = credentials.Resource(self, cli_args=_cli_args)
 
         self._auth_lock = Lock()
 

--- a/lavaclient/util.py
+++ b/lavaclient/util.py
@@ -683,3 +683,21 @@ def ssh_to_host(username, host, ssh_command=None, command=None):
         raise error.FailedError(msg)
 
     return output
+
+
+def confirm(message, default_yes=False):
+    """Present the user with a y/n choice. Returns True if the choice is `y`"""
+    choices = 'Y/n' if default_yes else 'y/N'
+
+    while True:
+        resp = six.moves.input('{0} [{1}] '.format(message, choices)).lower()
+
+        if not resp:
+            resp = 'y' if default_yes else 'n'
+
+        if resp in ('y', 'n'):
+            break
+
+        six.print_('Invalid selection: {0}'.format(resp))
+
+    return resp == 'y'

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import patch, MagicMock
+from mock import patch, MagicMock, Mock
 
 from lavaclient.client import Lava
 from lavaclient.cli import initialize_logging
@@ -15,7 +15,8 @@ def mock_client(request):
         'username',
         endpoint='http://dfw.bigdata.api.rackspacecloud.com/v2',
         token='token',
-        tenant_id=12345)
+        tenant_id=12345,
+        _cli_args=Mock(headless=True))
 
     client._request = MagicMock()
 


### PR DESCRIPTION
In the CLI, if we try to automatically upload the user's ssh keypair, but the keypair doesn't exist, catch the ensuing `IOError` and give the user instruction.