### PR TITLE
Add limits docs; fix limits response object

### DIFF
--- a/docs/api/limits.rst
+++ b/docs/api/limits.rst
@@ -3,6 +3,19 @@ Limits
 
 .. automodule:: lavaclient.api.limits
 
+Display aggregate resource limits for the tenant with which you authenticated.
+For example::
+
+    >>> limits = lava.limits.get()
+    >>> limits
+    AbsoluteLimits(disk, node_count, ram, vcpus)
+
+    >>> limits.vcpus
+    AbsoluteLimit(limit, remaining, used)
+
+    >>> (limits.vcpus.used, limits.vcpus.remaining, limits.vcpus.limit)
+    (12, 188, 200)
+
 
 API Reference
 -------------
@@ -11,11 +24,6 @@ API Reference
    :members:
 
 .. currentmodule:: lavaclient.api.response
-
-.. autoclass:: Limit()
-   :members:
-   :inherited-members:
-   :member-order: groupwise
 
 .. autoclass:: AbsoluteLimits()
    :members:

--- a/lavaclient/api/limits.py
+++ b/lavaclient/api/limits.py
@@ -17,7 +17,7 @@ from figgis import Config, Field
 from lavaclient.api import resource
 from lavaclient.util import CommandLine, command, display_table
 from lavaclient.log import NullHandler
-from lavaclient.api.response import Limit
+from lavaclient.api.response import AbsoluteLimits, Limit
 
 
 LOG = logging.getLogger(__name__)
@@ -47,12 +47,15 @@ class Resource(resource.Resource):
     @command(parser_options=dict(
         description='Get resource limits for the authenticated user',
     ))
-    @display_table(Limit)
+    @display_table(AbsoluteLimits)
     def get(self):
         """
         Get resource limits for the tenant.
+
+        :returns: :class:`AbsoluteLimits`
         """
-        return self._parse_response(
+        resp = self._parse_response(
             self._client._get('/limits'),
             LimitsResponse,
             wrapper='limits')
+        return resp.absolute

--- a/lavaclient/api/response.py
+++ b/lavaclient/api/response.py
@@ -592,17 +592,17 @@ class Credentials(Config):
         print_table(data, ('Type', 'Name'))
 
 
-class AbsoluteLimit(Config):
+class AbsoluteLimit(Config, ReprMixin):
 
     limit = Field(int, required=True)
     remaining = Field(int, required=True)
 
-    def __repr__(self):
-        return 'AbsoluteLimit(limit={0}, remaining={1})'.format(
-            self.limit, self.remaining)
+    @property
+    def used(self):
+        return self.limit - self.remaining
 
 
-class AbsoluteLimits(Config):
+class AbsoluteLimits(Config, ReprMixin):
 
     node_count = Field(AbsoluteLimit, required=True,
                        help='See: :class:`AbsoluteLimit`')
@@ -613,20 +613,18 @@ class AbsoluteLimits(Config):
     vcpus = Field(AbsoluteLimit, required=True,
                   help='See: :class:`AbsoluteLimit`')
 
-
-class Limit(Config):
-
-    absolute = Field(AbsoluteLimits, required=True,
-                     help='See: :class:`AbsoluteLimits`')
-
     def display(self):
-        data = self.absolute
-
         properties = [
-            ('Nodes', data.node_count.limit, data.node_count.remaining),
-            ('RAM', data.ram.limit, data.ram.remaining),
-            ('Disk', data.disk.limit, data.disk.remaining),
-            ('VCPUs', data.vcpus.limit, data.vcpus.remaining),
+            ('Nodes', self.node_count.limit, self.node_count.remaining),
+            ('RAM', self.ram.limit, self.ram.remaining),
+            ('Disk', self.disk.limit, self.disk.remaining),
+            ('VCPUs', self.vcpus.limit, self.vcpus.remaining),
         ]
         header = ('Property', 'Limit', 'Remaining')
         print_table(properties, header, title='Quotas')
+
+
+class Limit(Config, ReprMixin):
+
+    absolute = Field(AbsoluteLimits, required=True,
+                     help='See: :class:`AbsoluteLimits`')

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -1,7 +1,7 @@
 import pytest
 from mock import patch
 
-from lavaclient.api.response import Limit, AbsoluteLimit
+from lavaclient.api.response import AbsoluteLimits
 from lavaclient import error
 
 
@@ -10,13 +10,8 @@ def test_get(lavaclient, limits_response):
         request.return_value = limits_response
         resp = lavaclient.limits.get()
 
-        assert isinstance(resp, Limit)
+        assert isinstance(resp, AbsoluteLimits)
 
     with patch.object(lavaclient, '_request') as request:
         request.return_value = {}
         pytest.raises(error.ApiError, lavaclient.limits.get)
-
-
-def test_limit_repr(absolute_limit):
-    alimit = AbsoluteLimit(absolute_limit)
-    assert repr(alimit) == 'AbsoluteLimit(limit=10, remaining=0)'


### PR DESCRIPTION
Originally, `client.limits.get` forced you to access the `absolute` attribute before getting any useful information.  Now that method returns the content of the `absolute` attribute instead of the wrapped response.