### PR TITLE
Fix credentials issue in CLI cluster create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.2.3
+-----
+* Fix cluster create bug in CLI in which missing credentials are not detected
+  properly
+
 0.2.2
 -----
 * Client

--- a/lavaclient/api/clusters.py
+++ b/lavaclient/api/clusters.py
@@ -449,8 +449,10 @@ class Resource(resource.Resource):
                                user_scripts, node_groups, connectors, wait)
         except error.RequestError as exc:
             if self._args.headless or not (
-                    ssh_keys == [DEFAULT_SSH_KEY] and
-                    'Cannot find requested ssh_keys' in str(exc)):
+                    ssh_keys == [DEFAULT_SSH_KEY] and (
+                        'Cannot find requested ssh_keys' in str(exc) or
+                        'One or more ssh_keys are invalid' in str(exc)
+                    )):
                 raise
 
         # Create the SSH key for the user and then attempt to create the


### PR DESCRIPTION
Turns out there's another message that's returned when the request ssh key isn't available.