### PR TITLE
Upgrade keystone/oslo deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 -----
 * Fix cluster create bug in CLI in which missing credentials are not detected
   properly
+* Update dependencies for keystoneclient and oslo.i18n to avoid library
+  conflict issue
 
 0.2.2
 -----

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-python-keystoneclient>=1.3.0
+python-keystoneclient>=1.6.0
+oslo.i18n>=1.7.0
 requests>=2.5.1
 six>=1.9.0
 python-dateutil>=2.4.2


### PR DESCRIPTION
Upgrade `python_keystoneclient` and `oslo.i18n` dependencies to fix library conflict issue.