### PR TITLE
Display service user creds on cluster create

### DIFF
--- a/lavaclient/api/response.py
+++ b/lavaclient/api/response.py
@@ -185,6 +185,15 @@ class ClusterScript(Config, ReprMixin):
     status = Field(six.text_type, required=True)
 
 
+class ServiceUser(Config, ReprMixin):
+
+    table_columns = ('service', 'username', 'password')
+
+    service = Field(six.text_type, required=True)
+    username = Field(six.text_type, required=True)
+    password = Field(six.text_type)
+
+
 class BaseCluster(object):
 
     @property
@@ -278,6 +287,8 @@ class ClusterDetail(Config, ReprMixin, BaseCluster):
     scripts = ListField(ClusterScript, required=True,
                         help='See: :class:`ClusterScript`')
     progress = Field(float, required=True)
+    service_users = ListField(ServiceUser,
+                              help='See: :class:`ServiceUser`')
 
     def display(self):
         display_result(self, ClusterDetail, title='Cluster')
@@ -289,6 +300,11 @@ class ClusterDetail(Config, ReprMixin, BaseCluster):
         if self.scripts:
             six.print_()
             display_result(self.scripts, ClusterScript, title='Scripts')
+
+        if self.service_users:
+            six.print_()
+            display_result(self.service_users, ServiceUser,
+                           title='Service Users')
 
 
 class Flavor(Config, ReprMixin):

--- a/lavaclient/keystone.py
+++ b/lavaclient/keystone.py
@@ -48,10 +48,7 @@ class ApiKeyAuth(v2_auth.Auth):
         }
 
 
-class RaxAuthMixin(object):
-    """Mixin class for Keystone authentication plugins which injects
-    rackspace-specific data into authentication requests"""
-
+class PasswordAuth(v2_auth.Password):
     def get_auth_data(self, *args, **kwargs):
         data = super(PasswordAuth, self).get_auth_data(*args, **kwargs)
         data.update({
@@ -61,10 +58,6 @@ class RaxAuthMixin(object):
         })
 
         return data
-
-
-class PasswordAuth(v2_auth.Password, RaxAuthMixin):
-    pass
 
 
 class Client(v2_client.Client):


### PR DESCRIPTION
On cluster create, display credentials for any service users.  Note that these will not be returned by any other cluster method, e.g. `get`