### PR TITLE
Improve nodes list display

### DIFF
--- a/lavaclient/api/clusters.py
+++ b/lavaclient/api/clusters.py
@@ -32,7 +32,8 @@ from lavaclient.api.response import Cluster, ClusterDetail, Node, ReprMixin
 from lavaclient import error
 from lavaclient.validators import Length, Range, List
 from lavaclient.util import (CommandLine, argument, command, display_table,
-                             coroutine, create_socks_proxy, expand, confirm)
+                             coroutine, create_socks_proxy, expand, confirm,
+                             display)
 from lavaclient.log import NullHandler
 
 
@@ -553,7 +554,7 @@ class Resource(resource.Resource):
     @command(parser_options=dict(
         description='List all nodes in the cluster'
     ))
-    @display_table(Node)
+    @display(Node.display_nodes)
     def nodes(self, cluster_id):
         """
         Get the cluster nodes

--- a/lavaclient/api/nodes.py
+++ b/lavaclient/api/nodes.py
@@ -5,7 +5,7 @@ from figgis import Config, ListField
 from lavaclient.api import resource
 from lavaclient import constants
 from lavaclient.api.response import Node
-from lavaclient.util import command, display_table, CommandLine
+from lavaclient.util import command, display, CommandLine
 
 LOG = logging.getLogger(constants.LOGGER_NAME)
 
@@ -32,7 +32,7 @@ class Resource(resource.Resource):
     @command(parser_options=dict(
         description='List all nodes in a cluster'
     ))
-    @display_table(Node)
+    @display(Node.display_nodes)
     def list(self, cluster_id):
         """
         List nodes belonging to the cluster.

--- a/tests/cli/test_clusters_cli.py
+++ b/tests/cli/test_clusters_cli.py
@@ -228,7 +228,8 @@ def test_wait(stdout, print_table, print_single_table, mock_client,
 
 
 @patch('sys.argv', ['lava', 'clusters', 'nodes', 'cluster_id'])
-def test_nodes(print_table, mock_client, nodes_response):
+@patch('lavaclient.api.response.print_table')
+def test_nodes(resp_print_table, print_table, mock_client, nodes_response):
     mock_client._request.return_value = nodes_response
     main()
 
@@ -237,7 +238,14 @@ def test_nodes(print_table, mock_client, nodes_response):
     assert alldata[:6] == ['node_id', 'NODENAME', '[]', 'ACTIVE', '1.2.3.4',
                            '5.6.7.8']
     assert header == Node.table_header
-    assert kwargs['title'] is None
+    assert kwargs['title'] == 'Nodes'
+
+    (data, header), kwargs = resp_print_table.call_args
+    alldata = [entry for entry in list(data)[0]]
+    assert alldata[:6] == ['NODENAME', 'component_name', 'Component name',
+                           'http://host']
+    assert header == ('Node', 'ID', 'Name', 'URI')
+    assert kwargs['title'] == 'Components'
 
 
 @patch('subprocess.Popen')

--- a/tests/cli/test_nodes_cli.py
+++ b/tests/cli/test_nodes_cli.py
@@ -5,7 +5,8 @@ from lavaclient.api.response import Node
 
 
 @patch('sys.argv', ['lava', 'nodes', 'list', 'cluster_id'])
-def test_list(print_table, mock_client, nodes_response):
+@patch('lavaclient.api.response.print_table')
+def test_list(resp_print_table, print_table, mock_client, nodes_response):
     mock_client._request.return_value = nodes_response
     main()
 
@@ -14,4 +15,11 @@ def test_list(print_table, mock_client, nodes_response):
     assert alldata[:6] == ['node_id', 'NODENAME', '[]', 'ACTIVE', '1.2.3.4',
                            '5.6.7.8']
     assert header == Node.table_header
-    assert kwargs['title'] is None
+    assert kwargs['title'] == 'Nodes'
+
+    (data, header), kwargs = resp_print_table.call_args
+    alldata = [entry for entry in list(data)[0]]
+    assert alldata[:6] == ['NODENAME', 'component_name', 'Component name',
+                           'http://host']
+    assert header == ('Node', 'ID', 'Name', 'URI')
+    assert kwargs['title'] == 'Components'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -318,8 +318,9 @@ def node(link_response):
         },
         'components': [
             {
-                "name": 'component_name',
-                "uri": 'http://host'
+                'name': 'component_name',
+                'nice_name': 'Component name',
+                'uri': 'http://host'
             }
         ],
         "links": [link_response]


### PR DESCRIPTION
Instead of displaying components alongside the nodes (which is really ugly and cluttered), display components information *after* the nodes in a separate table.

## New

```
+-----------------------------------------------------------------------------------------------------------+
|                                                   Nodes                                                   |
+--------------------------------------+-------------+-----------+--------+----------------+----------------+
|                  ID                  |     Name    |    Role   | Status |   Public IP    |   Private IP   |
+--------------------------------------+-------------+-----------+--------+----------------+----------------+
| 456e09ef-5c7a-42e7-9342-2a27bdf91c44 |   master-1  |   master  | ACTIVE | xxx.xxx.xxx.xx | xx.xxx.xxx.xxx |
| db11e16c-0fd1-470e-9623-263b8bc2f6c2 |  gateway-1  |  gateway  | ACTIVE | xxx.xxx.xxx.xx | xx.xxx.xxx.xxx |
| f19bb4f5-9215-4562-9382-c052cbc02d18 | secondary-1 | secondary | ACTIVE | xxx.xxx.xxx.xx | xx.xxx.xxx.xxx |
| f819d5ad-d610-4143-936c-9a1049a198cd |   slave-1   |   slave   | ACTIVE | xxx.xxx.xxx.xx | xx.xxx.xxx.xxx |
+--------------------------------------+-------------+-----------+--------+----------------+----------------+
+-----------------------------------------------------------------------------------------------------------+
|                                                 Components                                                |
+-------------+-----------------------+------------------------------+--------------------------------------+
|     Node    |           ID          |             Name             |                 URI                  |
+-------------+-----------------------+------------------------------+--------------------------------------+
|   master-1  |        Namenode       |        HDFS Namenode         |     http://master-1.local:50070      |
|             |    ResourceManager    |    YARN Resource Manager     |      http://master-1.local:8088      |
|             |      FlumeHandler     |            Flume             |                                      |
|  gateway-1  |      HiveServer2      |         Hive Server          |       thrift://gateway-1.local       |
|             |     HiveMetastore     |        Hive Metastore        |                                      |
|             |        HiveAPI        |           Hive API           |                                      |
|             |       HiveClient      |         Hive Client          |                                      |
|             |       PigClient       |          Pig Client          |                                      |
|             |        MRClient       |       MapReduce Client       |                                      |
|             |      SqoopClient      |         Sqoop Client         |                                      |
|             |      OozieClient      |         Oozie Client         |                                      |
|             |      FlumeHandler     |            Flume             |                                      |
|             |    ZookeeperClient    |       Zookeeper Client       |                                      |
| secondary-1 |   SecondaryNamenode   |   HDFS Secondary Namenode    |    http://secondary-1.local:50090    |
|             |    MRHistoryServer    |   MapReduce History Server   |    http://secondary-1.local:19888    |
|             | TimelineHistoryServer | YARN Timeline History Server |    http://secondary-1.local:8188     |
|             |      OozieServer      |         Oozie Server         | http://secondary-1.local:11000/oozie |
|             |      FlumeHandler     |            Flume             |                                      |
|   slave-1   |        Datanode       |        HDFS Datanode         |      http://slave-1.local:50075      |
|             |      NodeManager      |      YARN Node Manager       |      http://slave-1.local:8042       |
|             |      FlumeHandler     |            Flume             |                                      |
+-------------+-----------------------+------------------------------+--------------------------------------+
```

## Old

```
+--------------------------------------+-------------+-----------+--------+----------------+----------------+---------------------------------+
|                  ID                  |     Name    |    Role   | Status |   Public IP    |   Private IP   |            Components           |
+--------------------------------------+-------------+-----------+--------+----------------+----------------+---------------------------------+
| 456e09ef-5c7a-42e7-9342-2a27bdf91c44 |   master-1  |   master  | ACTIVE | xxx.xxx.xxx.xx | xx.xxx.xxx.xxx |    [{nice_name=HDFS Namenode,   |
|                                      |             |           |        |                |                |  name=Namenode, uri=http://mast |
|                                      |             |           |        |                |                |        er-1.local:50070},       |
|                                      |             |           |        |                |                |     {nice_name=YARN Resource    |
|                                      |             |           |        |                |                |  Manager, name=ResourceManager, |
|                                      |             |           |        |                |                |  uri=http://master-1.local:8088 |
|                                      |             |           |        |                |                |                },               |
|                                      |             |           |        |                |                |        {nice_name=Flume,        |
|                                      |             |           |        |                |                |       name=FlumeHandler}]       |
| db11e16c-0fd1-470e-9623-263b8bc2f6c2 |  gateway-1  |  gateway  | ACTIVE | xxx.xxx.xxx.xx | xx.xxx.xxx.xxx |     [{nice_name=Hive Server,    |
|                                      |             |           |        |                |                |        name=HiveServer2,        |
|                                      |             |           |        |                |                |  uri=thrift://gateway-1.local}, |
|                                      |             |           |        |                |                |    {nice_name=Hive Metastore,   |
|                                      |             |           |        |                |                |       name=HiveMetastore},      |
|                                      |             |           |        |                |                |       {nice_name=Hive API,      |
|                                      |             |           |        |                |                |          name=HiveAPI},         |
|                                      |             |           |        |                |                |     {nice_name=Hive Client,     |
|                                      |             |           |        |                |                |        name=HiveClient},        |
|                                      |             |           |        |                |                |      {nice_name=Pig Client,     |
|                                      |             |           |        |                |                |         name=PigClient},        |
|                                      |             |           |        |                |                |   {nice_name=MapReduce Client,  |
|                                      |             |           |        |                |                |         name=MRClient},         |
|                                      |             |           |        |                |                |     {nice_name=Sqoop Client,    |
|                                      |             |           |        |                |                |        name=SqoopClient},       |
|                                      |             |           |        |                |                |     {nice_name=Oozie Client,    |
|                                      |             |           |        |                |                |        name=OozieClient},       |
|                                      |             |           |        |                |                |        {nice_name=Flume,        |
|                                      |             |           |        |                |                |       name=FlumeHandler},       |
|                                      |             |           |        |                |                |   {nice_name=Zookeeper Client,  |
|                                      |             |           |        |                |                |      name=ZookeeperClient}]     |
| f19bb4f5-9215-4562-9382-c052cbc02d18 | secondary-1 | secondary | ACTIVE | xxx.xxx.xxx.xx | xx.xxx.xxx.xxx |    [{nice_name=HDFS Secondary   |
|                                      |             |           |        |                |                |            Namenode,            |
|                                      |             |           |        |                |                |  name=SecondaryNamenode, uri=ht |
|                                      |             |           |        |                |                |  tp://secondary-1.local:50090}, |
|                                      |             |           |        |                |                |   {nice_name=MapReduce History  |
|                                      |             |           |        |                |                |  Server, name=MRHistoryServer,  |
|                                      |             |           |        |                |                |  uri=http://secondary-1.local:1 |
|                                      |             |           |        |                |                |              9888},             |
|                                      |             |           |        |                |                |     {nice_name=YARN Timeline    |
|                                      |             |           |        |                |                |         History Server,         |
|                                      |             |           |        |                |                |  name=TimelineHistoryServer, ur |
|                                      |             |           |        |                |                |  i=http://secondary-1.local:818 |
|                                      |             |           |        |                |                |               8},               |
|                                      |             |           |        |                |                |     {nice_name=Oozie Server,    |
|                                      |             |           |        |                |                |  name=OozieServer, uri=http://s |
|                                      |             |           |        |                |                |  econdary-1.local:11000/oozie}, |
|                                      |             |           |        |                |                |        {nice_name=Flume,        |
|                                      |             |           |        |                |                |       name=FlumeHandler}]       |
| f819d5ad-d610-4143-936c-9a1049a198cd |   slave-1   |   slave   | ACTIVE | xxx.xxx.xxx.xx | xx.xxx.xxx.xxx |    [{nice_name=HDFS Datanode,   |
|                                      |             |           |        |                |                |  name=Datanode, uri=http://slav |
|                                      |             |           |        |                |                |        e-1.local:50075},        |
|                                      |             |           |        |                |                |  {nice_name=YARN Node Manager,  |
|                                      |             |           |        |                |                |        name=NodeManager,        |
|                                      |             |           |        |                |                | uri=http://slave-1.local:8042}, |
|                                      |             |           |        |                |                |        {nice_name=Flume,        |
|                                      |             |           |        |                |                |       name=FlumeHandler}]       |
+--------------------------------------+-------------+-----------+--------+----------------+----------------+---------------------------------+
```