### PR TITLE
Add ambari credential methods

### DIFF
--- a/docs/api/credentials.rst
+++ b/docs/api/credentials.rst
@@ -26,7 +26,7 @@ manually::
 
 Similarly, you can add credentials to access other services from your clusters,
 e.g. `Cloud Files <http://www.rackspace.com/cloud/files>`_, which you can
-enable using the `connectors` argument when creating a cluster::
+enable using the `credentials` argument when creating a cluster::
 
     >>> cloudfiles = lava.credentials.create_cloud_files('cloudfiles_user',
     ...                                                  'cloudfiles_apikey')
@@ -36,8 +36,13 @@ enable using the `connectors` argument when creating a cluster::
     ...     'HADOOP_HDP2_2',
     ...     username='scott',
     ...     ssh_keys=[ssh_key.id],
-    ...     connectors=[{'cloud_files': cloudfiles.id}],
+    ...     credentials=[{'cloud_files': cloudfiles.id}],
     ...     node_groups={'slave': {'count': 3, 'flavor_id': 'hadoop1-7'}})
+
+.. note::
+
+    The `connectors` argument has been replaced by `credentials`, which shares
+    the same format.
 
 .. note::
 
@@ -47,8 +52,8 @@ enable using the `connectors` argument when creating a cluster::
 
 .. note::
 
-    The currently supported credential types are SSH , Cloud Files, and Amazon
-    S3.
+    The currently supported credential types are SSH, Cloud Files, Ambari, and
+    Amazon S3.
 
 API Reference
 -------------
@@ -74,6 +79,11 @@ API Reference
    :member-order: groupwise
 
 .. autoclass:: S3Credential()
+   :members:
+   :inherited-members:
+   :member-order: groupwise
+
+.. autoclass:: AmbariCredential()
    :members:
    :inherited-members:
    :member-order: groupwise

--- a/lavaclient/api/credentials.py
+++ b/lavaclient/api/credentials.py
@@ -20,7 +20,8 @@ from figgis import Config, ListField, Field
 
 from lavaclient.api import resource
 from lavaclient.api.response import (Credentials, CloudFilesCredential, SSHKey,
-                                     S3Credential, CredentialType)
+                                     S3Credential, AmbariCredential,
+                                     CredentialType)
 from lavaclient.validators import Length
 from lavaclient.util import (CommandLine, argument, command, display_table,
                              file_or_string, confirm)
@@ -40,6 +41,7 @@ class Credential(Config):
     cloud_files = Field(CloudFilesCredential)
     ssh_keys = Field(SSHKey)
     s3 = Field(S3Credential)
+    ambari = Field(AmbariCredential)
 
 
 class CredentialsResponse(Config):
@@ -87,6 +89,14 @@ class CreateS3Request(Config):
                               validator=Length(min=40, max=40))
 
 
+class CreateAmbariRequest(Config):
+
+    username = Field(six.text_type, required=True, nullable=False,
+                     validator=Length(min=3, max=255))
+    password = Field(six.text_type, nullable=False, required=True,
+                     validator=Length(min=8, max=255))
+
+
 ######################################################################
 # API Resource
 ######################################################################
@@ -113,8 +123,7 @@ class Resource(resource.Resource):
         """
         List all credentials belonging to the tenant
 
-        :returns: List of :class:`Credentials`
-                  objects
+        :returns: List of :class:`Credentials` objects
         """
         return self._list()
 
@@ -153,6 +162,18 @@ class Resource(resource.Resource):
         :returns: List of :class:`S3Credential` objects
         """
         return self._list(type='s3')
+
+    @command(parser_options=dict(
+        description='List all Ambari credentials'
+    ))
+    @display_table(AmbariCredential)
+    def list_ambari(self):
+        """
+        List all Ambari credentials
+
+        :returns: List of :class:`AmbariCredential` objects
+        """
+        return self._list(type='ambari')
 
     def list_types(self):
         """
@@ -257,6 +278,35 @@ class Resource(resource.Resource):
 
     @command(
         parser_options=dict(
+            description='Add credentials for Ambari'
+        ),
+        username=argument(help='Ambari username'),
+        password=argument(help='Password')
+    )
+    @display_table(AmbariCredential)
+    def create_ambari(self, username, password):
+        """
+        Create credentials for Ambari access
+
+        :param username: Ambari username
+        :param password: Password
+        :returns: :class:`AmbariCredential`
+        """
+        data = dict(
+            username=username,
+            password=password,
+        )
+        request_data = self._marshal_request(
+            data, CreateAmbariRequest, wrapper='ambari')
+
+        resp = self._parse_response(
+            self._client._post('credentials/ambari', json=request_data),
+            CredentialResponse,
+            wrapper='credentials')
+        return resp.ambari
+
+    @command(
+        parser_options=dict(
             description='Update SSH key'
         ),
         name=argument(metavar='<name>', help='Name of existing SSH key'),
@@ -348,6 +398,36 @@ class Resource(resource.Resource):
         return resp.s3
 
     @command(
+        parser_options=dict(
+            description='Update credentials for Ambari'
+        ),
+        username=argument(help='Username for existing Ambari credential'),
+        password=argument(help='Password')
+    )
+    @display_table(AmbariCredential)
+    def update_ambari(self, username, password):
+        """
+        Update credentials for Ambari access
+
+        :param username: Ambari username
+        :param password: Password
+        :returns: :class:`AmbariCredential`
+        """
+        data = dict(
+            username=username,
+            password=password)
+        request_data = self._marshal_request(
+            data, CreateAmbariRequest, wrapper='ambari')
+
+        resp = self._parse_response(
+            self._client._put(
+                'credentials/ambari/{0}'.format(username),
+                json=request_data),
+            CredentialResponse,
+            wrapper='credentials')
+        return resp.ambari
+
+    @command(
         parser_options=dict(description='Delete an SSH key'),
         name=argument(help='SSH key name')
     )
@@ -367,7 +447,7 @@ class Resource(resource.Resource):
 
     @command(
         parser_options=dict(description='Delete a Cloud Files credential'),
-        name=argument(help='Cloud Files username')
+        username=argument(help='Cloud Files username')
     )
     def _delete_cloud_files(self, username):
         if not confirm('Delete Cloud Files username {0}?'.format(username)):
@@ -385,7 +465,7 @@ class Resource(resource.Resource):
 
     @command(
         parser_options=dict(description='Delete Amazon S3 credential'),
-        name=argument(help='Amazon S3 access key id')
+        access_key_id=argument(help='Amazon S3 access key id')
     )
     def _delete_s3(self, access_key_id):
         if not confirm('Delete S3 access key {0}?'.format(access_key_id)):
@@ -400,3 +480,21 @@ class Resource(resource.Resource):
         :param access_key_id: S3 access key id
         """
         self._client._delete('credentials/s3/{0}'.format(access_key_id))
+
+    @command(
+        parser_options=dict(description='Delete Ambari credential'),
+        username=argument(help='Ambari username')
+    )
+    def _delete_ambari(self, username):
+        if not confirm('Delete Ambari user {0}?'.format(username)):
+            return
+
+        return self.delete_ambari(username)
+
+    def delete_ambari(self, username):
+        """
+        Delete Ambari credential
+
+        :param username: Ambari username
+        """
+        self._client._delete('credentials/ambari/{0}'.format(username))

--- a/lavaclient/api/response.py
+++ b/lavaclient/api/response.py
@@ -50,7 +50,7 @@ class ReprMixin(object):
         ordered = []
         for key in ('id', 'name'):
             if key in properties:
-                ordered.append("{0}='{1}'".format(key, self.get(key)))
+                ordered.append("{0}='{1}'".format(key, getattr(self, key)))
                 properties.remove(key)
 
         # Next come any other id's
@@ -280,6 +280,28 @@ class Cluster(Config, ReprMixin, BaseCluster):
 class ClusterDetail(Config, ReprMixin, BaseCluster):
     """Detailed cluster information"""
 
+    def parse_cluster_credentials(value):
+        result = {
+            's3': [],
+            'cloud_files': [],
+            'ambari': [],
+            'ssh_keys': [],
+        }
+
+        attr_names = {
+            's3': 'access_key_id',
+            'cloud_files': 'username',
+            'ambari': 'username',
+            'ssh_keys': 'key_name',
+        }
+
+        for item in value:
+            type_ = item['type']
+            cred = {'type': type_, attr_names[type_]: item['name']}
+            result[type_].append(cred)
+
+        return Credentials(result)
+
     __inherits__ = [Cluster]
 
     table_columns = ('id', 'name', 'status', 'stack_id', 'created',
@@ -293,6 +315,7 @@ class ClusterDetail(Config, ReprMixin, BaseCluster):
     scripts = ListField(ClusterScript, required=True,
                         help='See: :class:`ClusterScript`')
     progress = Field(float, required=True)
+    credentials = Field(parse_cluster_credentials, required=True)
 
     def display(self):
         display_result(self, ClusterDetail, title='Cluster')
@@ -593,7 +616,7 @@ class CloudFilesCredential(Config, ReprMixin):
         self._client.credentials.delete_cloud_files(self.username)
 
 
-class S3Credential(Config):
+class S3Credential(Config, ReprMixin):
 
     table_columns = ('type', 'access_key_id')
     table_header = ('Type', 'Access Key ID')
@@ -611,17 +634,36 @@ class S3Credential(Config):
         self.__client.credentials.delete_s3(self.access_key_id)
 
 
-class Credentials(Config):
+class AmbariCredential(Config, ReprMixin):
+
+    table_columns = ('type', 'username')
+
+    type = 'Ambari'
+    username = Field(six.text_type, required=True)
+
+    @property
+    def id(self):
+        """Equivalent to :attr:`username`"""
+        return self.username
+
+    def delete(self):
+        """Delete s3 credential"""
+        self.__client.credentials.delete_ambari(self.username)
+
+
+class Credentials(Config, ReprMixin):
 
     cloud_files = ListField(CloudFilesCredential)
     ssh_keys = ListField(SSHKey)
     s3 = ListField(S3Credential)
+    ambari = ListField(AmbariCredential)
 
     def display(self):
         data = chain(
             [('SSH Key', key.name) for key in self.ssh_keys],
             [('Cloud Files', cred.username) for cred in self.cloud_files],
-            [('Amazon S3', cred.access_key_id) for cred in self.s3]
+            [('Amazon S3', cred.access_key_id) for cred in self.s3],
+            [('Ambari', cred.username) for cred in self.ambari]
         )
         print_table(data, ('Type', 'Name'))
 

--- a/lavaclient/util.py
+++ b/lavaclient/util.py
@@ -28,6 +28,7 @@ import base64
 import os.path
 import six.moves.urllib as urllib
 import socks
+import warnings
 from sockshandler import SocksiPyHandler
 from functools import wraps
 from collections import namedtuple
@@ -728,3 +729,7 @@ def confirm(message, default_yes=False):
         six.print_('Invalid selection: {0}'.format(resp))
 
     return resp == 'y'
+
+
+def deprecation(message):
+    warnings.warn(message, DeprecationWarning, stacklevel=2)

--- a/tests/cli/test_credentials_cli.py
+++ b/tests/cli/test_credentials_cli.py
@@ -13,7 +13,8 @@ def test_list(print_table_, mock_client, credentials_response):
     (data, header), kwargs = print_table_.call_args
     assert list(data) == [('SSH Key', 'mykey'),
                           ('Cloud Files', 'username'),
-                          ('Amazon S3', 'access_key_id')]
+                          ('Amazon S3', 'access_key_id'),
+                          ('Ambari', 'username')]
     assert header == ('Type', 'Name')
     assert 'title' not in kwargs
 
@@ -44,8 +45,7 @@ def test_list_cloud_files(print_table, mock_client,
 
 
 @patch('sys.argv', ['lava', 'credentials', 'list_s3'])
-def test_list_s3(print_table, mock_client,
-                 s3_creds_response):
+def test_list_s3(print_table, mock_client, s3_creds_response):
     mock_client._request.return_value = s3_creds_response
     main()
 
@@ -53,6 +53,18 @@ def test_list_s3(print_table, mock_client,
     (data, header), kwargs = print_table.call_args
     assert list(data) == [['Amazon S3', 'access_key_id']]
     assert header == ('Type', 'Access Key ID')
+    assert kwargs['title'] is None
+
+
+@patch('sys.argv', ['lava', 'credentials', 'list_ambari'])
+def test_list_ambari(print_table, mock_client, ambari_creds_response):
+    mock_client._request.return_value = ambari_creds_response
+    main()
+
+    assert print_table.call_count == 1
+    (data, header), kwargs = print_table.call_args
+    assert list(data) == [['Ambari', 'username']]
+    assert header == ['Type', 'Username']
     assert kwargs['title'] is None
 
 
@@ -97,6 +109,19 @@ def test_create_s3(print_single_table, mock_client,
     assert kwargs['title'] is None
 
 
+@patch('sys.argv', ['lava', 'credentials', 'create_ambari', 'username',
+                    'password'])
+def test_create_ambari(print_single_table, mock_client, ambari_cred_response):
+    mock_client._request.return_value = ambari_cred_response
+    main()
+
+    assert print_single_table.call_count == 1
+    (data, header), kwargs = print_single_table.call_args
+    assert data == ['Ambari', 'username']
+    assert header == ['Type', 'Username']
+    assert kwargs['title'] is None
+
+
 @patch('sys.argv', ['lava', 'credentials', 'update_ssh_key', 'name',
                     'x' * 50])
 def test_update_ssh_key(print_single_table, mock_client, ssh_key_response):
@@ -126,8 +151,7 @@ def test_update_cloud_files(print_single_table, mock_client,
 
 @patch('sys.argv', ['lava', 'credentials', 'update_s3', 'a' * 20,
                     'x' * 40])
-def test_update_s3(print_single_table, mock_client,
-                   s3_cred_response):
+def test_update_s3(print_single_table, mock_client, s3_cred_response):
     mock_client._request.return_value = s3_cred_response
     main()
 
@@ -135,6 +159,19 @@ def test_update_s3(print_single_table, mock_client,
     (data, header), kwargs = print_single_table.call_args
     assert data == ['Amazon S3', 'access_key_id']
     assert header == ('Type', 'Access Key ID')
+    assert kwargs['title'] is None
+
+
+@patch('sys.argv', ['lava', 'credentials', 'update_ambari', 'username',
+                    'password'])
+def test_update_ambari(print_single_table, mock_client, ambari_cred_response):
+    mock_client._request.return_value = ambari_cred_response
+    main()
+
+    assert print_single_table.call_count == 1
+    (data, header), kwargs = print_single_table.call_args
+    assert data == ['Ambari', 'username']
+    assert header == ['Type', 'Username']
     assert kwargs['title'] is None
 
 
@@ -153,9 +190,15 @@ def test_delete_cloud_files(mock_client):
     main()
 
 
-@patch('sys.argv', ['lava', 'credentials', 'delete_s3',
-                    'username'])
+@patch('sys.argv', ['lava', 'credentials', 'delete_s3', 'access_key_id'])
 @patch('lavaclient.api.credentials.confirm', MagicMock(return_value=True))
 def test_delete_s3(mock_client):
+    mock_client._request.return_value = None
+    main()
+
+
+@patch('sys.argv', ['lava', 'credentials', 'delete_ambari', 'username'])
+@patch('lavaclient.api.credentials.confirm', MagicMock(return_value=True))
+def test_delete_ambari(mock_client):
     mock_client._request.return_value = None
     main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,7 +125,13 @@ def cluster_detail(cluster, node_group, cluster_script):
         node_groups=[node_group],
         username='username',
         scripts=[cluster_script],
-        progress=1.0
+        progress=1.0,
+        credentials=[
+            {'type': 'ssh_keys', 'name': 'mykey'},
+            {'type': 'cloud_files', 'name': 'username'},
+            {'type': 'ambari', 'name': 'username'},
+            {'type': 's3', 'name': 'accesskey'},
+        ],
     )
     return data
 
@@ -348,6 +354,11 @@ def s3():
 
 
 @pytest.fixture
+def ambari():
+    return {'username': 'username', 'password': 'password'}
+
+
+@pytest.fixture
 def ssh_key_response(ssh_key):
     return {'credentials': {'ssh_keys': ssh_key}}
 
@@ -378,11 +389,22 @@ def s3_creds_response(s3):
 
 
 @pytest.fixture
-def credentials_response(ssh_key, cloud_files, s3):
+def ambari_cred_response(ambari):
+    return {'credentials': {'ambari': ambari}}
+
+
+@pytest.fixture
+def ambari_creds_response(ambari):
+    return {'credentials': {'ambari': [ambari]}}
+
+
+@pytest.fixture
+def credentials_response(ssh_key, cloud_files, s3, ambari):
     return {
         'credentials': {
             'ssh_keys': [ssh_key],
             'cloud_files': [cloud_files],
             's3': [s3],
+            'ambari': [ambari],
         }
     }

--- a/tests/test_clusters.py
+++ b/tests/test_clusters.py
@@ -5,70 +5,38 @@ from lavaclient.api import response
 from lavaclient import error
 
 
-@pytest.fixture
-def cluster_fixture(link_response):
-    return {
-        'id': 'cluster_id',
-        'created': '2014-01-01',
-        'updated': None,
-        'name': 'cluster_name',
-        'status': 'ACTIVE',
-        'stack_id': 'stack_id',
-        'cbd_version': 1,
-        'links': [link_response],
-    }
-
-
-@pytest.fixture
-def cluster_detail_fixture(cluster_fixture, node_group, cluster_script):
-    data = cluster_fixture.copy()
-    data.update(
-        node_groups=[node_group],
-        username='username',
-        scripts=[cluster_script],
-        progress=1.0
-    )
-    return data
-
-
-def test_api_list(lavaclient, cluster_fixture):
+def test_api_list(lavaclient, clusters_response):
     with patch.object(lavaclient, '_request') as request:
-        request.return_value = {'clusters': []}
-        resp = lavaclient.clusters.list()
-        assert isinstance(resp, list)
-        assert len(resp) == 0
-
-    with patch.object(lavaclient, '_request') as request:
-        request.return_value = {'clusters': [cluster_fixture]}
+        request.return_value = clusters_response
         resp = lavaclient.clusters.list()
         assert isinstance(resp, list)
         assert len(resp) == 1
         assert isinstance(resp[0], response.Cluster)
 
 
-def test_api_get(lavaclient, cluster_detail_fixture):
+def test_api_get(lavaclient, cluster_response):
     with patch.object(lavaclient, '_request') as request:
-        request.return_value = {'cluster': cluster_detail_fixture}
+        request.return_value = cluster_response
         resp = lavaclient.clusters.get('cluster_id')
         assert isinstance(resp, response.ClusterDetail)
 
 
-def test_api_create(lavaclient, cluster_detail_fixture):
+def test_api_create(lavaclient, cluster_response):
     with patch.object(lavaclient, '_request') as request:
-        request.return_value = {'cluster': cluster_detail_fixture}
+        request.return_value = cluster_response
         resp = lavaclient.clusters.create(
             'cluster_name', 'stack_id')
         assert isinstance(resp, response.ClusterDetail)
 
     with patch.object(lavaclient, '_request') as request:
-        request.return_value = {'cluster': cluster_detail_fixture}
+        request.return_value = cluster_response
         resp = lavaclient.clusters.create(
             'cluster_name', 'stack_id',
             node_groups=[])
         assert isinstance(resp, response.ClusterDetail)
 
     with patch.object(lavaclient, '_request') as request:
-        request.return_value = {'cluster': cluster_detail_fixture}
+        request.return_value = cluster_response
         resp = lavaclient.clusters.create(
             'cluster_name', 'stack_id',
             node_groups=[{
@@ -85,10 +53,10 @@ def test_api_create(lavaclient, cluster_detail_fixture):
                   node_groups=[{'id': 'x' * 256}])
 
 
-def test_api_resize(lavaclient, cluster_detail_fixture):
+def test_api_resize(lavaclient, cluster_response):
     with patch.object(lavaclient, '_request') as request:
 
-        request.return_value = {'cluster': cluster_detail_fixture}
+        request.return_value = cluster_response
         resp = lavaclient.clusters.resize(
             'cluster_id',
             node_groups=[{
@@ -106,9 +74,9 @@ def test_api_resize(lavaclient, cluster_detail_fixture):
                   'cluster_id', node_groups=[{'id': 'node_id'}])
 
 
-def test_api_delete(lavaclient, cluster_fixture):
+def test_api_delete(lavaclient, cluster_response):
     with patch.object(lavaclient, '_request') as request:
-        request.return_value = {'cluster': cluster_fixture}
+        request.return_value = cluster_response
         resp = lavaclient.clusters.delete('cluster_id')
         assert resp is None
 


### PR DESCRIPTION
Several changes to reflect recent credentials handling changes in the API:

- In `clusters.create`, `connectors` are deprecated in favor of `credentials`
- Added Ambari credentials management