### PR TITLE
Remove ambari node from ssh-able nodes list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.2.6
+-----
+* Fix SSH methods bug in which ambari node is targeted
+
 0.2.5
 -----
 * General

--- a/lavaclient/_version.py
+++ b/lavaclient/_version.py
@@ -10,5 +10,5 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-__version_info__ = (0, 2, 5)
+__version_info__ = (0, 2, 6)
 __version__ = '.'.join(map(str, __version_info__))

--- a/lavaclient/api/clusters.py
+++ b/lavaclient/api/clusters.py
@@ -627,10 +627,10 @@ class Resource(resource.Resource):
 
     def _cluster_nodes(self, cluster_id, wait=False):
         """
-        Return `(cluster, nodes)`, where `nodes` is a list of all nodes in the
-        cluster. If the cluster is not ACTIVE/ERROR and wait is `True`, the
-        function will block until it becomes active; otherwise, an exception
-        is thrown.
+        Return `(cluster, nodes)`, where `nodes` is a list of all non-Ambari
+        nodes in the cluster. If the cluster is not ACTIVE/ERROR and wait is
+        `True`, the function will block until it becomes active; otherwise, an
+        exception is thrown.
         """
         cluster = self.get(cluster_id)
         status = cluster.status.upper()
@@ -645,7 +645,9 @@ class Resource(resource.Resource):
 
             self.wait(cluster_id)
 
-        return cluster, self.nodes(cluster_id)
+        nodes = [node for node in self.nodes(cluster_id)
+                 if node.name.lower() != 'ambari']
+        return cluster, nodes
 
     @command(
         parser_options=dict(


### PR DESCRIPTION
Since the Ambari node doesn't allow SSH access, remove it from the list of nodes that can be SSH'ed to.