### PR TITLE
Add automatic retries on network errors and 503 responses

### DIFF
--- a/lavaclient/cli.py
+++ b/lavaclient/cli.py
@@ -76,6 +76,12 @@ def create_client(args):
                                   os.environ.get('LAVA2_API_URL'),
                                   os.environ.get('LAVA_API_URL')),
             verify_ssl=args.verify_ssl,
+            timeout=first_exists(args.request_timeout,
+                                 os.environ.get('LAVA_TIMEOUT')),
+            max_retries=first_exists(args.retries,
+                                     os.environ.get('LAVA_RETRIES')),
+            retry_backoff=first_exists(args.retry_backoff,
+                                       os.environ.get('LAVA_RETRY_BACKOFF')),
             _cli_args=args)
     except LavaError as exc:
         six.print_('Error during authentication: {0}'.format(exc),
@@ -266,6 +272,16 @@ def parse_argv():
         general.add_argument('--insecure', '-k', action='store_false',
                              dest='verify_ssl',
                              help='Turn of SSL cert validation')
+        general.add_argument('--retries', type=int,
+                             help='Number of times to retry on connection '
+                                  'errors')
+        general.add_argument('--retry-backoff', type=float,
+                             help='Amount of time to increase the delay '
+                                  'between retry attempts, in fractional '
+                                  'seconds.')
+        general.add_argument('--request-timeout', type=int,
+                             help='Amount of time to wait for a response, '
+                                  'in seconds')
 
         fmt = prs.add_argument_group('Formatting Options')
         with_opposites(fmt, 'pretty_print', '--format', '-f',

--- a/lavaclient/constants.py
+++ b/lavaclient/constants.py
@@ -14,6 +14,9 @@
 
 # Internals
 LOGGER_NAME = 'lavaclient'
+DEFAULT_TIMEOUT = 30
+DEFAULT_RETRIES = 3
+DEFAULT_RETRY_BACKOFF = 0.2
 
 
 # Authentication

--- a/lavaclient/error.py
+++ b/lavaclient/error.py
@@ -49,6 +49,11 @@ class FailedError(LavaError):
     pass
 
 
+class ConnectionError(LavaError):
+    """The API could not be reached"""
+    pass
+
+
 class TimeoutError(LavaError):
     """The action timed out"""
     pass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,7 @@ from mock import patch, MagicMock
 import pytest
 import requests
 
+from lavaclient import constants
 from lavaclient import error
 from lavaclient import __version__
 
@@ -10,41 +11,45 @@ from lavaclient import __version__
 def test_requests(uuid4, lavaclient):
     uuid4.return_value = 'uuid'
 
-    with patch('requests.request') as request:
+    with patch('requests.sessions.Session.request') as request:
         lavaclient._get('path')
         request.assert_called_with(
             'GET', 'v2/tenant_id/path',
             verify=False,
+            timeout=constants.DEFAULT_TIMEOUT,
             headers={'X-Auth-Token': 'auth_token',
                      'Client-Request-ID': 'uuid',
                      'User-Agent': 'python-lavaclient {0}'.format(
                          __version__)})
 
-    with patch('requests.request') as request:
+    with patch('requests.sessions.Session.request') as request:
         lavaclient._post('path')
         request.assert_called_with(
             'POST', 'v2/tenant_id/path',
             verify=False,
+            timeout=constants.DEFAULT_TIMEOUT,
             headers={'X-Auth-Token': 'auth_token',
                      'Client-Request-ID': 'uuid',
                      'User-Agent': 'python-lavaclient {0}'.format(
                          __version__)})
 
-    with patch('requests.request') as request:
+    with patch('requests.sessions.Session.request') as request:
         lavaclient._put('path')
         request.assert_called_with(
             'PUT', 'v2/tenant_id/path',
             verify=False,
+            timeout=constants.DEFAULT_TIMEOUT,
             headers={'X-Auth-Token': 'auth_token',
                      'Client-Request-ID': 'uuid',
                      'User-Agent': 'python-lavaclient {0}'.format(
                          __version__)})
 
-    with patch('requests.request') as request:
+    with patch('requests.sessions.Session.request') as request:
         lavaclient._delete('path')
         request.assert_called_with(
             'DELETE', 'v2/tenant_id/path',
             verify=False,
+            timeout=constants.DEFAULT_TIMEOUT,
             headers={'X-Auth-Token': 'auth_token',
                      'Client-Request-ID': 'uuid',
                      'User-Agent': 'python-lavaclient {0}'.format(
@@ -55,11 +60,12 @@ def test_requests(uuid4, lavaclient):
 def test_headers(uuid4, lavaclient):
     uuid4.return_value = 'uuid'
 
-    with patch('requests.request') as request:
+    with patch('requests.sessions.Session.request') as request:
         lavaclient._get('path', headers={'foo': 'bar'})
         request.assert_called_with(
             'GET', 'v2/tenant_id/path',
             verify=False,
+            timeout=constants.DEFAULT_TIMEOUT,
             headers={'foo': 'bar',
                      'X-Auth-Token': 'auth_token',
                      'Client-Request-ID': 'uuid',
@@ -79,7 +85,7 @@ def test_reauthenticate(lavaclient):
         )
     )
 
-    with patch('requests.request') as request:
+    with patch('requests.sessions.Session.request') as request:
         # First call mocks 401 error, second call goes through
         request.side_effect = [
             MagicMock(raise_for_status=MagicMock(
@@ -108,7 +114,7 @@ def test_reauthenticate_failure(lavaclient):
         )
     )
 
-    with patch('requests.request') as request:
+    with patch('requests.sessions.Session.request') as request:
         request.return_value = MagicMock(raise_for_status=MagicMock(
             side_effect=requests.exceptions.HTTPError(
                 response=MagicMock(status_code=requests.codes.unauthorized)
@@ -119,7 +125,7 @@ def test_reauthenticate_failure(lavaclient):
         assert request.call_count == 2
 
 
-@patch('requests.request')
+@patch('requests.sessions.Session.request')
 def test_http_error(request, lavaclient):
     request.return_value = MagicMock(
         raise_for_status=MagicMock(
@@ -141,7 +147,7 @@ def test_http_error(request, lavaclient):
     assert exception.code == requests.codes.internal_server_error
 
 
-@patch('requests.request')
+@patch('requests.sessions.Session.request')
 def test_request_exception(request, lavaclient):
     request.return_value = MagicMock(
         raise_for_status=MagicMock(


### PR DESCRIPTION
I wasn't able to properly mock the guts of urllib3 in such
a way as to create unit tests for the retries, but I did
manual testing and it worked as expected.