### PR TITLE
Allow SSH to IMPAIRED clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 -----
 * CLI
     * Fixed --version flag
+* You may now SSH to any cluster not in ERROR status, including IMPAIRED
+  clusters
 
 0.2.8
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
+0.2.9
+-----
+* CLI
+    * Fixed --version flag
+
 0.2.8
-----
+-----
 * CLI
     * Add update_credentials and delete_ssh_credentials commands
     * Remove restrictions on credential names in type=name pairs

--- a/docs/api/clusters.rst
+++ b/docs/api/clusters.rst
@@ -77,6 +77,16 @@ On the command line, you have a few additional useful commands available::
     Use Ctrl-C to stop proxy
     ^CSOCKS proxy closed
 
+.. note::
+
+    The `ssh_proxy` command will allow you to access web interfaces for the
+    various services installed on your cluster, e.g. the YARN Web UI (you can
+    find the URL's for the services installed on your cluster using the
+    :meth:`~lavaclient.api.clusters.Resource.nodes` method or CLI command).
+    However, you will have to set up your browser to access the SOCKS proxy
+    using the information provided.  Note that this is a SOCKS 5 proxy, not
+    SOCKS 4.
+
 
 API Reference
 -------------

--- a/lavaclient/_version.py
+++ b/lavaclient/_version.py
@@ -10,5 +10,5 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-__version_info__ = (0, 2, 8)
+__version_info__ = (0, 2, 9)
 __version__ = '.'.join(map(str, __version_info__))

--- a/lavaclient/cli.py
+++ b/lavaclient/cli.py
@@ -255,6 +255,8 @@ def parse_argv():
         general.add_argument('--tenant',
                              help='Tenant ID')
         general.add_argument('--version',
+                             action='version',
+                             version=__version__,
                              help='Print client version')
         general.add_argument('--debug', '-d', action='count',
                              help='Print debugging information; use multiple '
@@ -326,10 +328,6 @@ def parse_argv():
 
 def main():
     args = parse_argv()
-    if args.version:
-        six.print_('lavaclient version ' + __version__)
-        sys.exit(0)
-
     initialize_logging(args)
 
     try:

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,18 @@
+#! /usr/bin/env bash
+
+set -eu -o pipefail
+
+# Verify that PyPi package display is valid
+echo "Checking PyPi package HTML"
+if ! python setup.py --long-description | rst2html.py --strict > /dev/null; then
+    echo
+    echo "Error: invalid package display; check CHANGELOG.md"
+    exit 1
+fi
+
+# Build package
+rm -rf build dist
+python setup.py sdist bdist_wheel
+
+# Upload to PyPi
+twine upload -u rax_cbd_dev dist/*


### PR DESCRIPTION
Allow SSH to impaired clusters.  Also do some housekeeping, e.g. creating release script, adding some missing docs, and fixing the `--version` flag.