### PR TITLE
Show node component names instead of json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 -----
 * CLI
     * Fixed --version flag
+    * Updated cluster node groups format to show component names instead of
+      raw JSON
 * You may now SSH to any cluster not in ERROR status, including IMPAIRED
   clusters
 

--- a/lavaclient/api/response.py
+++ b/lavaclient/api/response.py
@@ -180,7 +180,6 @@ class Node(Config, ReprMixin):
         return self._ssh(username, command=command, ssh_command=ssh_command)
 
 
-@prettify('components')
 class NodeGroup(Config, ReprMixin):
     """Group of nodes that share the same flavor and installed services"""
 
@@ -318,12 +317,25 @@ class ClusterDetail(Config, ReprMixin, BaseCluster):
     progress = Field(float, required=True)
     credentials = Field(parse_cluster_credentials, required=True)
 
+    def display_node_groups(self):
+        data = []
+        for group in self.node_groups:
+            data.extend(zip(
+                chain([group.id], repeat('')),
+                chain([group.flavor_id], repeat('')),
+                chain([group.count], repeat('')),
+                sorted(component['name'] for component in group.components)
+            ))
+
+        print_table(data, ('ID', 'Flavor', 'Count', 'Components'),
+                    title='Node Groups')
+
     def display(self):
         display_result(self, ClusterDetail, title='Cluster')
 
         if self.node_groups:
             six.print_()
-            display_result(self.node_groups, NodeGroup, title='Node Groups')
+            self.display_node_groups()
 
         if self.scripts:
             six.print_()

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -42,9 +42,16 @@ def mock_client(request):
 
 @pytest.fixture
 def print_table(request):
-    patcher = patch('lavaclient.util.print_table')
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
+    func = MagicMock()
+    for path in ('lavaclient.api.response',
+                 'lavaclient.api.stacks',
+                 'lavaclient.api.workloads',
+                 'lavaclient.util'):
+        patcher = patch(path + '.print_table', func)
+        request.addfinalizer(patcher.stop)
+        patcher.start()
+
+    return func
 
 
 @pytest.fixture

--- a/tests/cli/test_clusters_cli.py
+++ b/tests/cli/test_clusters_cli.py
@@ -40,7 +40,7 @@ def test_get(print_table, print_single_table, mock_client, cluster_response):
     assert print_table.call_count == 2
 
     (data, header), kwargs = print_table.call_args_list[0]
-    assert list(data) == [['id', 'hadoop1-60', 1, '[{name=component}]']]
+    assert list(data) == [('id', 'hadoop1-60', 1, 'component')]
     assert header == NodeGroup.table_header
     assert kwargs['title'] == 'Node Groups'
 
@@ -266,7 +266,7 @@ def test_wait(stdout, print_table, print_single_table, mock_client,
     assert print_table.call_count == 2
 
     (data, header), kwargs = print_table.call_args_list[0]
-    assert list(data) == [['id', 'hadoop1-60', 1, '[{name=component}]']]
+    assert list(data) == [('id', 'hadoop1-60', 1, 'component')]
     assert header == NodeGroup.table_header
     assert kwargs['title'] == 'Node Groups'
 
@@ -277,19 +277,19 @@ def test_wait(stdout, print_table, print_single_table, mock_client,
 
 
 @patch('sys.argv', ['lava', 'clusters', 'nodes', 'cluster_id'])
-@patch('lavaclient.api.response.print_table')
-def test_nodes(resp_print_table, print_table, mock_client, nodes_response):
+def test_nodes(print_table, mock_client, nodes_response):
     mock_client._request.return_value = nodes_response
     main()
 
-    (data, header), kwargs = print_table.call_args
+    assert print_table.call_count == 2
+    (data, header), kwargs = print_table.call_args_list[0]
     alldata = [entry for entry in list(data)[0]]
     assert alldata[:6] == ['node_id', 'NODENAME', 'node_group', 'ACTIVE',
                            '1.2.3.4', '5.6.7.8']
     assert header == Node.table_header
     assert kwargs['title'] == 'Nodes'
 
-    (data, header), kwargs = resp_print_table.call_args
+    (data, header), kwargs = print_table.call_args_list[1]
     alldata = [entry for entry in list(data)[0]]
     assert alldata[:6] == ['NODENAME', 'component_name', 'Component name',
                            'http://host']

--- a/tests/cli/test_credentials_cli.py
+++ b/tests/cli/test_credentials_cli.py
@@ -4,13 +4,12 @@ from lavaclient.cli import main
 
 
 @patch('sys.argv', ['lava', 'credentials', 'list'])
-@patch('lavaclient.api.response.print_table')
-def test_list(print_table_, mock_client, credentials_response):
+def test_list(print_table, mock_client, credentials_response):
     mock_client._request.return_value = credentials_response
     main()
 
-    assert print_table_.call_count == 1
-    (data, header), kwargs = print_table_.call_args
+    assert print_table.call_count == 1
+    (data, header), kwargs = print_table.call_args
     assert list(data) == [('SSH Key', 'mykey'),
                           ('Cloud Files', 'username'),
                           ('Amazon S3', 'access_key_id'),

--- a/tests/cli/test_limits_cli.py
+++ b/tests/cli/test_limits_cli.py
@@ -4,7 +4,6 @@ from lavaclient.cli import main
 
 
 @patch('sys.argv', ['lava', 'limits', 'get'])
-@patch('lavaclient.api.response.print_table')
 def test_get(print_table, mock_client, limits_response):
     mock_client._request.return_value = limits_response
     main()

--- a/tests/cli/test_nodes_cli.py
+++ b/tests/cli/test_nodes_cli.py
@@ -5,19 +5,20 @@ from lavaclient.api.response import Node
 
 
 @patch('sys.argv', ['lava', 'nodes', 'list', 'cluster_id'])
-@patch('lavaclient.api.response.print_table')
-def test_list(resp_print_table, print_table, mock_client, nodes_response):
+def test_list(print_table, mock_client, nodes_response):
     mock_client._request.return_value = nodes_response
     main()
 
-    (data, header), kwargs = print_table.call_args
+    assert print_table.call_count == 2
+
+    (data, header), kwargs = print_table.call_args_list[0]
     alldata = [entry for entry in list(data)[0]]
     assert alldata[:6] == ['node_id', 'NODENAME', 'node_group', 'ACTIVE',
                            '1.2.3.4', '5.6.7.8']
     assert header == Node.table_header
     assert kwargs['title'] == 'Nodes'
 
-    (data, header), kwargs = resp_print_table.call_args
+    (data, header), kwargs = print_table.call_args_list[1]
     alldata = [entry for entry in list(data)[0]]
     assert alldata[:6] == ['NODENAME', 'component_name', 'Component name',
                            'http://host']

--- a/tests/cli/test_stacks_cli.py
+++ b/tests/cli/test_stacks_cli.py
@@ -7,20 +7,13 @@ from lavaclient.cli import main
 from lavaclient.api.response import StackDetail, StackNodeGroup
 
 
-@pytest.fixture
-def print_table_(request):
-    patcher = patch('lavaclient.api.stacks.print_table')
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
-
-
 @patch('sys.argv', ['lava', 'stacks', 'list'])
-def test_list(print_table_, mock_client, stacks_response):
+def test_list(print_table, mock_client, stacks_response):
     mock_client._request.return_value = stacks_response
     main()
 
-    assert print_table_.call_count == 2
-    (data, header), kwargs = print_table_.call_args_list[0]
+    assert print_table.call_count == 2
+    (data, header), kwargs = print_table.call_args_list[0]
     alldata = list(data)
     assert len(alldata) == 1
     assert list(item[:5] for item in alldata) == [[1,
@@ -51,9 +44,9 @@ def test_get(print_table, print_single_table, mock_client, stack_response):
     assert header == StackDetail.table_header
     assert kwargs['title'] == 'Stack'
 
-    assert print_table.call_count == 1
+    assert print_table.call_count == 2
 
-    (data, header), kwargs = print_table.call_args
+    (data, header), kwargs = print_table.call_args_list[0]
     assert list(data) == [['id', 'hadoop1-7', 10, 1024, 1, 10]]
     assert header == StackNodeGroup.table_header
     assert kwargs['title'] == 'Node Groups'
@@ -102,9 +95,9 @@ def test_create(services, node_groups, print_table, print_single_table,
     assert header == StackDetail.table_header
     assert kwargs['title'] == 'Stack'
 
-    assert print_table.call_count == 1
+    assert print_table.call_count == 2
 
-    (data, header), kwargs = print_table.call_args
+    (data, header), kwargs = print_table.call_args_list[0]
     assert list(data) == [['id', 'hadoop1-7', 10, 1024, 1, 10]]
     assert header == StackNodeGroup.table_header
     assert kwargs['title'] == 'Node Groups'

--- a/tests/cli/test_workloads_cli.py
+++ b/tests/cli/test_workloads_cli.py
@@ -5,15 +5,6 @@ from lavaclient.cli import main
 from lavaclient.api.workloads import Workload
 
 
-@pytest.fixture
-def api_print_table(request):
-    pytest.skip('Workloads is disabled for now')
-
-    patcher = patch('lavaclient.api.workloads.print_table')
-    request.addfinalizer(patcher.stop)
-    return patcher.start()
-
-
 @patch('sys.argv', ['lava', 'workloads', 'list'])
 def test_list(print_table, mock_client, workloads_response):
     pytest.skip('Workloads is disabled for now')
@@ -28,7 +19,7 @@ def test_list(print_table, mock_client, workloads_response):
 
 
 @pytest.mark.parametrize('persistence', ['all', 'data', 'none'])
-def test_recommendations(persistence, api_print_table, mock_client,
+def test_recommendations(persistence, print_table, mock_client,
                          recommendations_response):
     pytest.skip('Workloads is disabled for now')
 
@@ -42,7 +33,7 @@ def test_recommendations(persistence, api_print_table, mock_client,
     assert params['storagesize'] == 128
     assert params['persistent'] == persistence
 
-    (data, header), kwargs = api_print_table.call_args
+    (data, header), kwargs = print_table.call_args
     assert len(list(data)) == 1
     assert header == ('Name', 'Requires', 'Description', 'Flavor', 'Minutes',
                       'Nodes', 'Recommended')


### PR DESCRIPTION
Instead of showing a series of `{name='component'}`, just show the component names