### PR TITLE
Add print_dict_table for table-ifying arbitrary dicts

### DIFF
--- a/lavaclient/util.py
+++ b/lavaclient/util.py
@@ -172,6 +172,16 @@ def print_single_table(data, header, title=None):
     print_titled(create_single_table(data, header), title)
 
 
+def print_dict_table(data, **kwargs):
+    """Print out arbitrary dictionaries in a table structure"""
+    headers, values = [], []
+    for header in sorted(six.iterkeys(data)):
+        headers.append(header)
+        values.append(data[header])
+
+    print_single_table(values, headers, **kwargs)
+
+
 def no_nulls(data):
     return ['' if item is None else item for item in data]
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -120,6 +120,38 @@ def test_print_single_table(data, header, title, output):
     assert strio.getvalue() == output
 
 
+@pytest.mark.parametrize('data,title,output', [
+    ({'foo': 1, 'bar': 2}, None, """\
++-----+---+
+| bar | 2 |
+| foo | 1 |
++-----+---+
+"""),
+    ({'foo': 1, 'bar': 2}, 'short', """\
++---------+
+|  short  |
++-----+---+
+| bar | 2 |
+| foo | 1 |
++-----+---+
+"""),
+    ({'foo': 1, 'bar': 2}, 'waytoofreakinglong', """\
++---------------------+
+|  waytoofreakinglong |
++-----------+---------+
+|    bar    |    2    |
+|    foo    |    1    |
++-----------+---------+
+"""),
+])
+def test_print_dict_table(data, title, output):
+    strio = six.StringIO()
+    with patch('sys.stdout', strio):
+        util.print_dict_table(data, title=title)
+
+    assert strio.getvalue() == output
+
+
 def test_inject_client():
     class SubSubConf(Config):
         field = Field(int)


### PR DESCRIPTION
I plan to use this in the admin client, but putting it
here with the related methods so it's available for both.