### PR TITLE
Fix unformatted output for single items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.2.10
+------
+* CLI
+    * Fix unformatted output for single-item requests, e.g. `clusters get`
+
 0.2.9
 -----
 * CLI

--- a/lavaclient/_version.py
+++ b/lavaclient/_version.py
@@ -10,5 +10,5 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-__version_info__ = (0, 2, 9)
+__version_info__ = (0, 2, 10)
 __version__ = '.'.join(map(str, __version_info__))

--- a/lavaclient/cli.py
+++ b/lavaclient/cli.py
@@ -109,7 +109,7 @@ def print_unformatted_table(args, result):
     result_list = [result] if isinstance(result, figgis.Config) else result
     response_class = result_list[0].__class__
 
-    data, long_header = table_data(result, response_class)
+    data, long_header = table_data(result_list, response_class)
     header = [item.replace(' ', '_').lower() for item in long_header]
 
     delim = six.text_type(args.delimiter)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,8 +1,10 @@
 import pytest
 import shlex
-from mock import patch
+import sys
+from mock import patch, Mock, call
+from figgis import Config, Field
 
-from lavaclient.cli import parse_argv
+from lavaclient.cli import parse_argv, print_unformatted_table
 
 
 @patch('sys.argv', ['lava', 'authenticate', '--token', 'mytoken'])
@@ -25,3 +27,22 @@ def test_argparse_order(pre_args, post_args, key, value):
         args = parse_argv()
 
     assert getattr(args, key) == value
+
+
+@patch('six.print_')
+def test_print_unformatted(sixprint):
+    class Conf(Config):
+        table_columns = ('field1', 'field2')
+
+        field1 = Field()
+        field2 = Field()
+
+    data = Conf(field1=1, field2=2)
+
+    fake_args = Mock(delimiter=',', show_header=False)
+    print_unformatted_table(fake_args, data)
+
+    sixprint.assert_has_calls([
+        call('field1,field2', file=sys.stderr),
+        call('1,2'),
+    ])


### PR DESCRIPTION
Fix the unformatted (i.e. `--no-format`) output for single-item methods, e.g. `clusters get`.