### PR TITLE
Don't show cli-specific output in shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------
 * CLI
     * Fix unformatted output for single-item requests, e.g. `clusters get`
+    * Shell command no longer displays command-line specific output
 
 0.2.9
 -----

--- a/lavaclient/api/resource.py
+++ b/lavaclient/api/resource.py
@@ -49,7 +49,7 @@ class Resource(object):
     def __init__(self, client, cli_args=None):
         self._client = client
         self._args = cli_args
-        self._command_line = cli_args is not None
+        self._command_line = cli_args.enable_cli if cli_args else False
 
     def _parse_response(self, data, response_class, wrapper=None):
         """

--- a/lavaclient/cli.py
+++ b/lavaclient/cli.py
@@ -35,6 +35,10 @@ def create_client(args):
     """
     Create instance of Lava from CLI args
     """
+    resource = args.resource
+    if resource == 'shell':
+        args.enable_cli = False
+
     apikey = first_exists(args.lava_api_key,
                           os.environ.get('LAVA_API_KEY'),
                           os.environ.get('OS_API_KEY'))
@@ -164,9 +168,6 @@ def execute_command(client, args):
     Execute lava command
     """
     resource = args.resource
-    if resource == 'shell':
-        args.enable_cli = False
-
     if resource in COMMAND_DISPATCH:
         COMMAND_DISPATCH[resource](client, args)
         sys.exit(0)


### PR DESCRIPTION
I wasn't setting the `_command_line` attribute in `Resource` objects properly, so CLI-specific output was still being printed while in the `shell` command for certain methods, the most notable of which was the `clusters.wait` method.