### PR TITLE
Add service management methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 env:
   - TOXENV=py26
   - TOXENV=py27
-  - TOXENV=py33
   - TOXENV=py34
 
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-0.2.10
-------
+0.3.0
+-----
 * CLI
     * Fix unformatted output for single-item requests, e.g. `clusters get`
     * Shell command no longer displays command-line specific output
+* Add ability to control (i.e. start, stop, or restart) services on a cluster
 
 0.2.9
 -----

--- a/lavaclient/_version.py
+++ b/lavaclient/_version.py
@@ -10,5 +10,5 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-__version_info__ = (0, 2, 10)
+__version_info__ = (0, 3, 0)
 __version__ = '.'.join(map(str, __version_info__))

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ oslo.i18n>=1.7.0
 requests>=2.5.1
 six>=1.9.0
 python-dateutil>=2.4.2
-figgis>=1.6.1
+figgis>=1.6.2
 PySocks>=1.5.4
+importlib>=1.0.3; python_version < '3.1'

--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,26 @@
 
 
 from setuptools import setup, find_packages
+import sys
 import os.path
 
 
 CHANGELOG_PATH = os.path.join(
     os.path.abspath(os.path.dirname(__file__)),
     'CHANGELOG.md')
+
+INSTALL_REQUIRES = [
+    'python-keystoneclient>=1.6.0',
+    'oslo.i18n>=1.7.0',
+    'requests>=2.5.1',
+    'six>=1.9.0',
+    'python-dateutil>=2.4.2',
+    'figgis>=1.6.2',
+    'pysocks>=1.5.4',
+]
+
+if sys.version_info < (3, 1):
+    INSTALL_REQUIRES.append('importlib>=1.0.3')
 
 
 def read_version():
@@ -75,14 +89,7 @@ if __name__ == '__main__':
         entry_points={
             'console_scripts': ['lava = lavaclient.cli:main'],
         },
-        install_requires=[
-            'python-keystoneclient>=1.3.0',
-            'requests>=2.5.1',
-            'six>=1.9.0',
-            'python-dateutil>=2.4.2',
-            'figgis>=1.6.2',
-            'PySocks>=1.5.4',
-        ],
+        install_requires=INSTALL_REQUIRES,
 
         classifiers=[
             "Development Status :: 4 - Beta",


### PR DESCRIPTION
You can now start/stop/restart services on a cluster, so long as they're running Ambari (which is pretty much everything).