### PR TITLE
Re-enable universal wheel packages

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -13,7 +13,6 @@ fi
 # Build package
 rm -rf build dist
 python setup.py sdist bdist_wheel
-python3 setup.py bdist_wheel || echo "Python 3 not supported"
 
 # Upload to PyPi
 twine upload -u rax_cbd_dev dist/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 description-file = README.md
 
 [wheel]
-universal = 0
+universal = 1


### PR DESCRIPTION
Re-enable universal (python 2/3) wheel packages, since we no longer have version-dependent dependencies.