### PR TITLE
Make node group ID regex more lenient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.3.5
+-----
+* CLI
+    * In commands that require specifying a node group ID, the validation
+      regex is more lenient
+
 0.3.4
 -----
 * Add missing prettytable dependency

--- a/lavaclient/_version.py
+++ b/lavaclient/_version.py
@@ -10,5 +10,5 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-__version_info__ = (0, 3, 4)
+__version_info__ = (0, 3, 5)
 __version__ = '.'.join(map(str, __version_info__))

--- a/lavaclient/api/clusters.py
+++ b/lavaclient/api/clusters.py
@@ -177,10 +177,10 @@ class ClusterCredentialsRemovalRequest(Config):
 def parse_node_group(value):
     """Parse command-line node group string, e.g.
     `slave(count=1, flavor_id=hadoop1-7)`"""
-    var_rgx = r'(?:[a-zA-Z-]\w*)'
+    var_rgx = r'(?:[a-zA-Z_]\w*)'
     expr_rgx = r'(?:{var}\s*=\s*.*?)'.format(var=var_rgx)
-    node_group_rgx = r'({var})(?:\(({expr}?(?:\s*,\s*{expr})*)\))?$'.format(
-        var=var_rgx, expr=expr_rgx)
+    node_group_rgx = r'([^()]+)(?:\(({expr}?(?:\s*,\s*{expr})*)\))?$'.format(
+        expr=expr_rgx)
 
     match = re.match(node_group_rgx, value)
     if match is None:

--- a/tests/cli/test_clusters_cli.py
+++ b/tests/cli/test_clusters_cli.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 
 from lavaclient.cli import main
 from lavaclient.api.response import Cluster, ClusterDetail, NodeGroup, Node
-from lavaclient.api.clusters import DEFAULT_SSH_KEY
+from lavaclient.api.clusters import DEFAULT_SSH_KEY, parse_node_group
 from lavaclient.error import RequestError
 
 
@@ -40,6 +40,19 @@ def check_cluster_detail(print_single_table, print_table):
     assert list(data) == [['script_id', 'name', 'status']]
     assert header == ['ID', 'Name', 'Status']
     assert kwargs['title'] == 'Scripts'
+
+
+@pytest.mark.parametrize('group', [
+    'foo(count=1)',
+    'foo123(count=1)',
+    'foo-bar(count=1)',
+    'foo-1(count=1)',
+    'foo_bar(count=1)',
+    '190efgkln235u90erty901234124(count=1)',
+])
+def test_parse_node_group(group):
+    result = parse_node_group(group)
+    assert result == {'id': group.split('(', 1)[0], 'count': '1'}
 
 
 @patch('sys.argv', ['lava', 'clusters', 'list'])


### PR DESCRIPTION
The API is more lenient on node group ID's than the client allows.  This lets the CLI accept any node group ID that does not contain parentheses.

Note that the API also allows for parentheses, but come on.