### PR TITLE
Allow cluster actions to work with cluster ID or name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
-0.3.9
+0.3.8
 -----
 * CLI
     * Add ability to delete individual nodes
-
-0.3.8
------
 * Validate cluster usernames
+* Cluster actions can use either the cluster ID or name
 
 0.3.7
 -----

--- a/lavaclient/__init__.py
+++ b/lavaclient/__init__.py
@@ -21,8 +21,7 @@ from lavaclient.client import Lava
 from lavaclient.log import NullHandler
 from lavaclient.error import (
     LavaError, InvalidError, AuthenticationError, AuthorizationError,
-    RequestError, ApiError, FailedError, TimeoutError, NotFoundError,
-    ProxyError)
+    RequestError, ApiError, FailedError, TimeoutError, ProxyError)
 
 
 __version_info__ = _version.__version_info__
@@ -35,4 +34,4 @@ LOG.addHandler(NullHandler())
 
 __all__ = ['Lava', 'LavaError', 'InvalidError', 'AuthenticationError',
            'AuthorizationError', 'RequestError', 'ApiError', 'FailedError',
-           'TimeoutError', 'NotFoundError', 'ProxyError']
+           'TimeoutError', 'ProxyError']

--- a/lavaclient/api/nodes.py
+++ b/lavaclient/api/nodes.py
@@ -2,6 +2,7 @@ import logging
 import six
 from figgis import Config, ListField
 
+from lavaclient.api.clusters import id_or_name
 from lavaclient.api import resource
 from lavaclient import constants
 from lavaclient.api.response import Node
@@ -39,10 +40,14 @@ class Resource(resource.Resource):
 
         :returns: List of :class:`~lavaclient.api.response.Node` objects
         """
-        return self._parse_response(
-            self._client._get('clusters/{0}/nodes'.format(cluster_id)),
-            NodesResponse,
-            wrapper='nodes')
+        @id_or_name
+        def _func(self, cluster_id):
+            return self._parse_response(
+                self._client._get('clusters/{0}/nodes'.format(cluster_id)),
+                NodesResponse,
+                wrapper='nodes')
+
+        return _func(self, cluster_id)
 
     @command(
         parser_options=dict(
@@ -65,5 +70,9 @@ class Resource(resource.Resource):
         :param node_id:
         :return: None
         """
-        self._client._delete('clusters/{0}/nodes/{1}'.format(cluster_id,
-                                                             node_id))
+        @id_or_name
+        def _func(self, cluster_id):
+            self._client._delete('clusters/{0}/nodes/{1}'.format(
+                cluster_id, node_id))
+
+        _func(self, cluster_id)

--- a/lavaclient/error.py
+++ b/lavaclient/error.py
@@ -59,11 +59,6 @@ class TimeoutError(LavaError):
     pass
 
 
-class NotFoundError(LavaError):
-    """The desired information was not found or did not exist"""
-    pass
-
-
 class ProxyError(LavaError):
     """Error in SOCKS proxy over SSH"""
     pass

--- a/tests/cli/test_clusters_cli.py
+++ b/tests/cli/test_clusters_cli.py
@@ -281,7 +281,9 @@ def test_wait(stdout, print_table, print_single_table, mock_client,
     active = deepcopy(cluster_response)
     active['cluster']['status'] = 'ACTIVE'
 
-    mock_client._request.side_effect = [building, configuring, active]
+    mock_client._request.side_effect = [
+        building, building, configuring, active
+    ]
 
     with patch.object(mock_client.clusters, '_command_line', True):
         main()


### PR DESCRIPTION
Allow cluster actions to work using either the cluster ID or name, e.g.

```bash
$ lava clusters get <cluster ID>
```

or...

```bash
$ lava clusters get <cluster name>
```